### PR TITLE
Use char literals instead of string literals for single characters

### DIFF
--- a/Securibox.FacturX/FacturxXsdValidator.cs
+++ b/Securibox.FacturX/FacturxXsdValidator.cs
@@ -17,7 +17,7 @@ namespace Securibox.FacturX
         public static void ValidateXml(XmlDocument xmlDocument, FacturXConformanceLevelType conformanceLevel)
         {
             var asm = Assembly.GetExecutingAssembly();
-            var resourcePrefix = $"{asm.GetName().Name}.Xsd.FacturX.{conformanceLevel.Name.Replace(" ","_")}.";
+            var resourcePrefix = $"{asm.GetName().Name}.Xsd.FacturX.{conformanceLevel.Name.Replace(' ', '_')}.";
 
             var resourceNames = asm.GetManifestResourceNames()
                                    .Where(r => r.StartsWith(resourcePrefix, StringComparison.OrdinalIgnoreCase)

--- a/Securibox.FacturX/Schematron/Types/Assert.cs
+++ b/Securibox.FacturX/Schematron/Types/Assert.cs
@@ -85,7 +85,7 @@ namespace Securibox.FacturX.Schematron.Types
             var result = fragment.DocumentElement?.InnerXml.Trim().Split('\n');
             if (result != null && result.Length > 0)
             {
-                return String.Join("\n", result.Select(x => x.Trim()));
+                return String.Join('\n', result.Select(x => x.Trim()));
             }
             else
             {
@@ -96,7 +96,7 @@ namespace Securibox.FacturX.Schematron.Types
         public virtual EvaluationResult Evaluate(Schema schema, XPathNavigator navigator, XsltContext context)
         {
             var result = false;
-            var assert = this.Test.Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ").Trim();
+            var assert = this.Test.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ').Trim();
             assert = System.Text.RegularExpressions.Regex.Replace(assert, @"\s+", " ");
             result = EvaluateLogicalExpression(context, navigator, assert);
 
@@ -202,7 +202,7 @@ namespace Securibox.FacturX.Schematron.Types
                 }
 
                 string condition = everyMatch.Groups[2].ToString().Trim();
-                if (condition.StartsWith("(") && condition.EndsWith(")"))
+                if (condition.StartsWith('(') && condition.EndsWith(')'))
                     condition = condition.Substring(1, condition.Length - 2);
 
                 if (variablesDictionary is null)
@@ -243,7 +243,7 @@ namespace Securibox.FacturX.Schematron.Types
                 }
 
                 string condition = someMatch.Groups[2].ToString().Trim();
-                if (condition.StartsWith("(") && condition.EndsWith(")"))
+                if (condition.StartsWith('(') && condition.EndsWith(')'))
                     condition = condition.Substring(1, condition.Length - 2);
 
                 foreach (var value in varValues)
@@ -330,7 +330,7 @@ namespace Securibox.FacturX.Schematron.Types
 
             var bindingParts = bindings.Split(',')
                 .Select(b => b.Trim())
-                .Where(b => b.StartsWith("$"))
+                .Where(b => b.StartsWith('$'))
                 .ToArray();
 
             if (variables is null)
@@ -447,7 +447,7 @@ namespace Securibox.FacturX.Schematron.Types
         private static string TrimOuterParentheses(string expr)
         {
             expr = expr.Trim();
-            while (expr.StartsWith("(") && expr.EndsWith(")"))
+            while (expr.StartsWith('(') && expr.EndsWith(')'))
             {
                 int depth = 0;
                 bool matched = false;

--- a/Securibox.FacturX/Schematron/Xslt/DynamicXPathVars.cs
+++ b/Securibox.FacturX/Schematron/Xslt/DynamicXPathVars.cs
@@ -65,7 +65,7 @@
             var sortedProps = lets.OrderBy(kv => kv.Key.ToString())
                                  .Select(kv => $"{kv.Key}:{(kv.Value?.GetType().FullName ?? "object")}");
 
-            return string.Join("|", sortedProps);
+            return string.Join('|', sortedProps);
         }
 
         private static TypeBuilder CreateTypeBuilder(string typeName)


### PR DESCRIPTION
Hi,

This PR proposes a small refactoring that replaces single character string literals with char literals wherever it makes sense. The intent is to reduce a few unnecessary allocations, [follow .NET best practices](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1865-ca1867), and keep the codebase consistent in its use of simple character operations.
I hope you find these improvements helpful.

Best regards,
Aymeric

## Changes Made

Replaced single-character string literals with char literals in:
 - `Replace(" ", "_")` → `Replace(' ', '_')`
 - `String.Join("\n", ...)` → `String.Join('\n', ...)`
 - `StartsWith("(")` / `EndsWith(")")` →`StartsWith('(')` / `EndsWith(')')`

## Technical Justification

**Why this matters:**
- **Memory allocation**: String literals create heap-allocated objects, while char literals are value types
- **Performance**: `string.Replace(char, char)` is faster than `string.Replace(string, string)`
- **JIT optimization**: Char-based methods have better JIT compilation paths

## Backward Compatibility

Fully backward compatible, this is a pure refactoring with no API changes

## Code Quality
- [Follows C# performance best practices](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1865-ca1867)
- Improves code consistency
- Aligns with .NET coding conventions