### PR TITLE
Update CreateFacturXStream to accept XML file path

### DIFF
--- a/Securibox.FacturX/FacturxExporter.cs
+++ b/Securibox.FacturX/FacturxExporter.cs
@@ -35,7 +35,7 @@ namespace Securibox.FacturX
             return CreateFacturXStream(File.OpenRead(pdfPath), File.OpenRead(xmlPath), conformanceLevel, documentTitle, documentDescription);
         }
 
-        public Stream CreateFacturXStream(string pdfPath, Invoice invoice, string documentTitle = "Invoice", string documentDescription = "Invoice description")
+        public Stream CreateFacturXStream(string pdfPath, string xmlPath, Invoice invoice, string documentTitle = "Invoice", string documentDescription = "Invoice description")
         {
             if (!File.Exists(pdfPath))
             {
@@ -45,10 +45,7 @@ namespace Securibox.FacturX
             {
                 throw new ArgumentNullException(nameof(invoice));
             }
-
-            var xmlPath = @"C:\Temp\FacturX\New folder\Lavarin\2023-6013 - Jappera - BASIC.xml";
-
-
+            
             var invoiceType = invoice.GetType();
             var conformanceLevel = FacturXConformanceLevelType.Minimum;
             if (invoiceType == typeof(Models.BasicWL.Invoice))


### PR DESCRIPTION
Hi,

This Pull Request performs a **refactoring** of the `CreateFacturXStream` method located in `FacturxExporter.cs`.

The method signature has been updated to **explicitly accept the XML file path** (`string xmlPath`) as an input parameter:

```csharp
// Old Signature
public Stream CreateFacturXStream(string pdfPath, Invoice invoice, ...)

// New Signature
public Stream CreateFacturXStream(string pdfPath, string xmlPath, Invoice invoice, ...)
```

This change allows for the **removal of a hardcoded XML path line** (`var xmlPath = @"C:\Temp\..."`) which was likely used for local testing or development purposes.

The goal is to improve flexibility and maintainability by allowing callers to specify the XML source dynamically.

Best regards,
Aymeric