### PR TITLE
[FIX] #56 TaxPointDate Extended and EN16931 type

### DIFF
--- a/Securibox.FacturX.Tests/FacturxExporterTests/EN16931InvoiceTests.cs
+++ b/Securibox.FacturX.Tests/FacturxExporterTests/EN16931InvoiceTests.cs
@@ -151,6 +151,14 @@ namespace Securibox.FacturX.Tests.FacturxExporterTests
                                                         TypeCode = "VAT",
                                                         CategoryCode = "S",
                                                         RateApplicablePercent = 10.00m,
+                                                        TaxPointDate = new SpecificationModels.Minimum.IssueDate()
+                                                        {
+                                                            DateString = new SpecificationModels.Minimum.DateString()
+                                                            {
+                                                                Value = "20230920",
+                                                                Format = "102",
+                                                            },
+                                                        },
                                                     },
                                                 SpecifiedTradeSettlementLineMonetarySummation =
                                                     new SpecificationModels.Basic.TradeSettlementLineMonetarySummation()

--- a/Securibox.FacturX.Tests/FacturxExporterTests/ExtendedInvoiceTests.cs
+++ b/Securibox.FacturX.Tests/FacturxExporterTests/ExtendedInvoiceTests.cs
@@ -354,6 +354,14 @@ namespace Securibox.FacturX.Tests.FacturxExporterTests
                                                     Value = 1235.40m,
                                                 },
                                                 RateApplicablePercent = 10.00m,
+                                                TaxPointDate = new SpecificationModels.Minimum.IssueDate()
+                                                {
+                                                    DateString = new SpecificationModels.Minimum.DateString()
+                                                    {
+                                                        Value = "20230920",
+                                                        Format = "102",
+                                                    },
+                                                },
                                             },
                                             new SpecificationModels.Extended.TradeTaxExtended()
                                             {

--- a/Securibox.FacturX/SpecificationModels/EN16931/TradeTaxEN16931.cs
+++ b/Securibox.FacturX/SpecificationModels/EN16931/TradeTaxEN16931.cs
@@ -8,7 +8,7 @@
         public Minimum.Amount BasisAmount { get; set; }
         public string CategoryCode { get; set; }
         public string ExemptionReasonCode { get; set; }
-        public Minimum.IssueDateTime TaxPointDate { get; set; }
+        public Minimum.IssueDate TaxPointDate { get; set; }
         public string DueDateTypeCode { get; set; }
         public decimal? RateApplicablePercent { get; set; }
     }

--- a/Securibox.FacturX/SpecificationModels/Extended/TradeTaxExtended.cs
+++ b/Securibox.FacturX/SpecificationModels/Extended/TradeTaxExtended.cs
@@ -10,7 +10,7 @@
         public Minimum.Amount AllowanceChargeBasisAmount { get; set; }
         public string CategoryCode { get; set; }
         public string ExemptionReasonCode { get; set; }
-        public Minimum.IssueDateTime TaxPointDate { get; set; }
+        public Minimum.IssueDate TaxPointDate { get; set; }
         public string DueDateTypeCode { get; set; }
         public decimal RateApplicablePercent { get; set; }
     }

--- a/Securibox.FacturX/SpecificationModels/Minimum/DateString.cs
+++ b/Securibox.FacturX/SpecificationModels/Minimum/DateString.cs
@@ -1,0 +1,22 @@
+using System.Xml.Serialization;
+
+namespace Securibox.FacturX.SpecificationModels.Minimum
+{
+    /// <summary>
+    /// Represents a date string with format attribute (udt:DateType element)
+    /// </summary>
+    public class DateString
+    {
+        /// <summary>
+        /// The date value (e.g., "20240220")
+        /// </summary>
+        [XmlText]
+        public string Value { get; set; }
+
+        /// <summary>
+        /// The date format code (e.g., "102" for YYYYMMDD)
+        /// </summary>
+        [XmlAttribute("format")]
+        public string Format { get; set; }
+    }
+}

--- a/Securibox.FacturX/SpecificationModels/Minimum/IssueDate.cs
+++ b/Securibox.FacturX/SpecificationModels/Minimum/IssueDate.cs
@@ -1,0 +1,10 @@
+using System.Xml.Serialization;
+
+namespace Securibox.FacturX.SpecificationModels.Minimum
+{
+    public class IssueDate
+    {
+        [XmlElement(Namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100")]
+        public DateString DateString { get; set; }
+    }
+}


### PR DESCRIPTION
For Extended and En16931 profils only :
- Creation of the class IssueDate only for date .
- Modification test to use TaxPointDate 

<img width="574" height="477" alt="image" src="https://github.com/user-attachments/assets/f938958c-59a5-47ee-9fe9-63be197d7865" />


