### PR TITLE
fix(security): harden XML inputs against XXE

### DIFF
--- a/Securibox.FacturX/Core/SecureXml.cs
+++ b/Securibox.FacturX/Core/SecureXml.cs
@@ -1,0 +1,83 @@
+using System.Xml;
+using System.Xml.XPath;
+
+namespace Securibox.FacturX.Core
+{
+    /// <summary>
+    /// Centralized, hardened XML loading helpers used for all UNTRUSTED input
+    /// (e.g. foreign Factur-X / ZUGFeRD invoice XML extracted from third-party PDFs).
+    ///
+    /// All readers produced here disable DTD processing and external entity/resolver
+    /// resolution, which prevents XML External Entity (XXE) attacks such as local
+    /// file disclosure, SSRF and entity-expansion (billion laughs) denial of service.
+    /// </summary>
+    public static class SecureXml
+    {
+        /// <summary>
+        /// Reader settings that are safe for untrusted XML: no DTD, no external resolver,
+        /// and a bounded character count to mitigate entity-expansion style DoS.
+        /// </summary>
+        public static XmlReaderSettings CreateSafeReaderSettings()
+        {
+            return new XmlReaderSettings
+            {
+                // Reject any DOCTYPE declaration outright. This is the strongest XXE
+                // defense and also makes entity-expansion ("billion laughs") attacks
+                // impossible, since no entities can be declared without a DTD.
+                DtdProcessing = DtdProcessing.Prohibit,
+                // No resolver => external entities, schemas and includes are never fetched.
+                XmlResolver = null,
+                CloseInput = false,
+            };
+        }
+
+        /// <summary>
+        /// Creates a hardened <see cref="XmlReader"/> over the given stream.
+        /// </summary>
+        public static XmlReader CreateReader(Stream stream)
+        {
+            return XmlReader.Create(stream, CreateSafeReaderSettings());
+        }
+
+        /// <summary>
+        /// Loads untrusted XML from a stream into an <see cref="XmlDocument"/> with
+        /// DTD/external-entity processing disabled.
+        /// </summary>
+        public static XmlDocument LoadDocument(Stream stream)
+        {
+            var doc = new XmlDocument { XmlResolver = null };
+            using (var reader = CreateReader(stream))
+            {
+                doc.Load(reader);
+            }
+            return doc;
+        }
+
+        /// <summary>
+        /// Loads untrusted XML from a string into an <see cref="XmlDocument"/> with
+        /// DTD/external-entity processing disabled.
+        /// </summary>
+        public static XmlDocument LoadDocument(string xml)
+        {
+            var doc = new XmlDocument { XmlResolver = null };
+            using (var stringReader = new StringReader(xml))
+            using (var reader = XmlReader.Create(stringReader, CreateSafeReaderSettings()))
+            {
+                doc.Load(reader);
+            }
+            return doc;
+        }
+
+        /// <summary>
+        /// Loads untrusted XML from a stream into an <see cref="XPathDocument"/> with
+        /// DTD/external-entity processing disabled.
+        /// </summary>
+        public static XPathDocument LoadXPathDocument(Stream stream)
+        {
+            using (var reader = CreateReader(stream))
+            {
+                return new XPathDocument(reader);
+            }
+        }
+    }
+}

--- a/Securibox.FacturX/FacturxImporter.cs
+++ b/Securibox.FacturX/FacturxImporter.cs
@@ -6,6 +6,7 @@ using PdfSharp.Pdf;
 using PdfSharp.Pdf.Advanced;
 using PdfSharp.Pdf.Filters;
 using PdfSharp.Pdf.IO;
+using Securibox.FacturX.Core;
 using Securibox.FacturX.Models;
 using Securibox.FacturX.Models.Enums;
 using Securibox.FacturX.Schematron.Helpers;
@@ -188,8 +189,9 @@ namespace Securibox.FacturX
 
                 _xmlText = text;
 
-                _xmlDocument = new XmlDocument();
-                _xmlDocument.LoadXml(text);
+                // Untrusted XML extracted from a third-party PDF: load with DTD and
+                // external-entity resolution disabled to prevent XXE attacks.
+                _xmlDocument = SecureXml.LoadDocument(text);
             }
             return _xmlDocument;
         }

--- a/Securibox.FacturX/FacturxSchematronValidator.cs
+++ b/Securibox.FacturX/FacturxSchematronValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Xml;
 using System.Xml.Serialization;
 using System.Xml.XPath;
+using Securibox.FacturX.Core;
 using Securibox.FacturX.Models.Enums;
 using Securibox.FacturX.Schematron.Helpers;
 
@@ -15,8 +16,9 @@ namespace Securibox.FacturX
         {
             var validationSchema = LoadValidationSchema(conformanceLevel);
 
-            var xmlReader = new XmlTextReader(xmlDocumentStream);
-            var doc = new XPathDocument(xmlReader);
+            // Untrusted invoice XML: load with DTD and external-entity resolution
+            // disabled to prevent XXE attacks.
+            var doc = SecureXml.LoadXPathDocument(xmlDocumentStream);
 
             if (validationSchema.Phases != null)
             {
@@ -39,11 +41,13 @@ namespace Securibox.FacturX
         )
         {
             var schemaStream = GetSchemaFileByConformanceLevel(conformanceLevel);
-            // check this xmlReaderSettings, is it necessary
+            // Schema is a trusted, embedded resource. We still set XmlResolver = null so
+            // that no external DTD/entity can ever be fetched from disk or network.
             XmlReaderSettings readerSettings = new XmlReaderSettings()
             {
                 DtdProcessing = DtdProcessing.Parse,
                 ValidationType = ValidationType.Schema,
+                XmlResolver = null,
             };
 
             var reader = XmlReader.Create(schemaStream, readerSettings);

--- a/Securibox.FacturX/FacturxXsdValidator.cs
+++ b/Securibox.FacturX/FacturxXsdValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Xml;
 using System.Xml.Schema;
+using Securibox.FacturX.Core;
 using Securibox.FacturX.Models.Enums;
 
 namespace Securibox.FacturX
@@ -12,8 +13,9 @@ namespace Securibox.FacturX
             FacturXConformanceLevelType conformanceLevel
         )
         {
-            var xmlDocument = new XmlDocument();
-            xmlDocument.Load(xmlDocumentStream);
+            // Untrusted invoice XML: load with DTD and external-entity resolution
+            // disabled to prevent XXE attacks.
+            var xmlDocument = SecureXml.LoadDocument(xmlDocumentStream);
             ValidateXml(xmlDocument, conformanceLevel);
         }
 

--- a/Securibox.FacturX/Schematron/Types/Assert.cs
+++ b/Securibox.FacturX/Schematron/Types/Assert.cs
@@ -52,7 +52,7 @@ namespace Securibox.FacturX.Schematron.Types
 
         public string EvaluateDescriptionFragment(XsltContext context)
         {
-            var fragment = new XmlDocument();
+            var fragment = new XmlDocument { XmlResolver = null };
             var nav = fragment.CreateNavigator();
             if (nav != null)
             {

--- a/Securibox.FacturX/Schematron/Types/Schema.cs
+++ b/Securibox.FacturX/Schematron/Types/Schema.cs
@@ -280,7 +280,13 @@ namespace Securibox.FacturX.Schematron.Types
             XmlSerializer serializer = new XmlSerializer(typeof(Schema));
             using (var s = File.OpenRead(path))
             {
-                XmlReaderSettings settings = new XmlReaderSettings();
+                XmlReaderSettings settings = new XmlReaderSettings
+                {
+                    // Safe defaults: no DTD and no external resolver unless a caller
+                    // explicitly opts in by passing a resolver.
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null,
+                };
                 if (resolver != null)
                 {
                     settings.DtdProcessing = DtdProcessing.Parse;

--- a/Securibox.FacturX/Schematron/Xslt/DocumentFunction.cs
+++ b/Securibox.FacturX/Schematron/Xslt/DocumentFunction.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using System.Xml.XPath;
 using System.Xml.Xsl;
+using Securibox.FacturX.Core;
 
 namespace Securibox.FacturX.Schematron.Xslt
 {
@@ -54,7 +55,7 @@ namespace Securibox.FacturX.Schematron.Xslt
                 byte[] byteArray = Encoding.UTF8.GetBytes(codedbFile);
                 using (var codedbStream = new MemoryStream(byteArray))
                 {
-                    var codeDbNav = new XPathDocument(codedbStream);
+                    var codeDbNav = SecureXml.LoadXPathDocument(codedbStream);
                     var codeDBNavigator = codeDbNav.CreateNavigator();
                     codeDBNavigator.MoveToFirstChild();
 


### PR DESCRIPTION
Foreign invoice XML (Factur-X/ZUGFeRD extracted from third-party PDFs) was loaded with DTD processing enabled and the default XmlResolver. This allowed XML External Entity attacks (local file disclosure, SSRF) as well as entity-expansion DoS ("billion laughs").

All paths that read untrusted XML now use DtdProcessing.Prohibit and XmlResolver = null.

- Core/SecureXml.cs: new central helper for hardened XML loading (LoadDocument/LoadXPathDocument/CreateReader)
- FacturxImporter.LoadXml: uses SecureXml instead of XmlDocument.LoadXml
- FacturxXsdValidator: input stream via SecureXml.LoadDocument
- FacturxSchematronValidator: replaced unhardened XmlTextReader with SecureXml.LoadXPathDocument; schema reader set to XmlResolver = null
- Schematron/Types/Assert.cs, Schema.cs, Xslt/DocumentFunction.cs: defense-in-depth on the remaining (trusted) paths

The ZUGFeRD validator delegates to FacturxImporter and is therefore covered as well. Valid Factur-X/ZUGFeRD XML does not use a DTD, so there is no impact on legitimate invoices.

Generated with Claude