### PR TITLE
fix: #41 fix and add test on HeaderTradeDelivery

### DIFF
--- a/Securibox.FacturX.Tests/FacturxExporterTests/EN16931InvoiceTests.cs
+++ b/Securibox.FacturX.Tests/FacturxExporterTests/EN16931InvoiceTests.cs
@@ -152,7 +152,7 @@ namespace Securibox.FacturX.Tests.FacturxExporterTests
                                                             Value = 6.0000m,
                                                         },
                                                 },
-                                        },
+                                                        },
                                     SpecifiedLineTradeSettlement =
                                         new SpecificationModels.EN16931.LineTradeSettlement()
                                         {
@@ -172,7 +172,7 @@ namespace Securibox.FacturX.Tests.FacturxExporterTests
                                                             Value = 1235.40m,
                                                         },
                                                 },
-                                        },
+                                                            },
                                     SpecifiedLineTradeDelivery =
                                         new SpecificationModels.Basic.LineTradeDelivery()
                                         {
@@ -336,6 +336,407 @@ namespace Securibox.FacturX.Tests.FacturxExporterTests
                                     {
                                         Name = "Securibox SARL",
                                     },
+                            },
+                        ApplicableHeaderTradeSettlement =
+                            new SpecificationModels.EN16931.HeaderTradeSettlement()
+                            {
+                                InvoiceCurrencyCode = "EUR",
+                                SpecifiedTradeSettlementPaymentMeans =
+                                [
+                                    new()
+                                    {
+                                        TypeCode = "30",
+                                        PayeePartyCreditorFinancialAccount = new()
+                                        {
+                                            IBANID = new SpecificationModels.Minimum.ID
+                                            {
+                                                Value = "FR7430003000402964223654P78",
+                                            },
+                                        },
+                                    },
+                                ],
+                                ApplicableTradeTax =
+                                    new SpecificationModels.EN16931.TradeTaxEN16931[]
+                                    {
+                                        new SpecificationModels.EN16931.TradeTaxEN16931()
+                                        {
+                                            CalculatedAmount =
+                                                new SpecificationModels.Minimum.Amount
+                                                {
+                                                    Value = 123.54m,
+                                                },
+                                            TypeCode = "VAT",
+                                            CategoryCode = "S",
+                                            BasisAmount = new SpecificationModels.Minimum.Amount
+                                            {
+                                                Value = 1235.40m,
+                                            },
+                                            RateApplicablePercent = 10.00m,
+                                        },
+                                        new SpecificationModels.EN16931.TradeTaxEN16931()
+                                        {
+                                            CalculatedAmount =
+                                                new SpecificationModels.Minimum.Amount
+                                                {
+                                                    Value = 0.00m,
+                                                },
+                                            TypeCode = "VAT",
+                                            CategoryCode = "Z",
+                                            BasisAmount = new SpecificationModels.Minimum.Amount
+                                            {
+                                                Value = 9.90m,
+                                            },
+                                            RateApplicablePercent = 0.00m,
+                                        },
+                                    },
+                                SpecifiedTradePaymentTerms =
+                                    new SpecificationModels.BasicWL.TradePaymentTerms()
+                                    {
+                                        DueDateDateTime =
+                                            new SpecificationModels.Minimum.IssueDateTime()
+                                            {
+                                                DateTimeString =
+                                                    new SpecificationModels.Minimum.DateTimeString()
+                                                    {
+                                                        Value = "20231019",
+                                                        Format = "102",
+                                                    },
+                                            },
+                                        Description = "30 jours net",
+                                    },
+                                SpecifiedTradeSettlementHeaderMonetarySummation =
+                                    new SpecificationModels.EN16931.TradeSettlementHeaderMonetarySummation()
+                                    {
+                                        LineTotalAmount = new SpecificationModels.Minimum.Amount()
+                                        {
+                                            Value = 1245.30m,
+                                        },
+                                        TaxBasisTotalAmount =
+                                            new SpecificationModels.Minimum.Amount()
+                                            {
+                                                Value = 1245.30m,
+                                            },
+                                        TaxTotalAmount = new SpecificationModels.Minimum.Amount[]
+                                        {
+                                            new SpecificationModels.Minimum.Amount()
+                                            {
+                                                Value = 123.54m,
+                                                CurrencyID = "EUR",
+                                            },
+                                        },
+                                        GrandTotalAmount = new SpecificationModels.Minimum.Amount()
+                                        {
+                                            Value = 1368.84m,
+                                        },
+                                        TotalPrepaidAmount =
+                                            new SpecificationModels.Minimum.Amount()
+                                            {
+                                                Value = 452.98m,
+                                            },
+                                        DuePayableAmount = new SpecificationModels.Minimum.Amount()
+                                        {
+                                            Value = 915.86m,
+                                        },
+                                    },
+                            },
+                    },
+            };
+
+            return invoice;
+        }
+
+        public static SpecificationModels.EN16931.CrossIndustryInvoice GetInvoice_SpecificationModels_witout_TradeDelivery()
+        {
+            var invoice = new Securibox.FacturX.SpecificationModels.EN16931.CrossIndustryInvoice()
+            {
+                ExchangedDocument = new SpecificationModels.BasicWL.ExchangedDocument()
+                {
+                    ID = new SpecificationModels.Minimum.ID { Value = "2023-6013" },
+                    IssueDateTime = new SpecificationModels.Minimum.IssueDateTime()
+                    {
+                        DateTimeString = new SpecificationModels.Minimum.DateTimeString()
+                        {
+                            Value = "20230920",
+                            Format = "102",
+                        },
+                    },
+                    TypeCode = "380",
+                    IncludedNote = new SpecificationModels.BasicWL.Note[]
+                    {
+                        new SpecificationModels.BasicWL.Note()
+                        {
+                            Content = "SASU au capital de 200000€",
+                            SubjectCode = "REG",
+                        },
+                        new SpecificationModels.BasicWL.Note()
+                        {
+                            Content = "R.C.S Paris 123 456 789",
+                            SubjectCode = "ABL",
+                        },
+                        new SpecificationModels.BasicWL.Note()
+                        {
+                            Content = "2, rue de la Paix – 75000 Paris – Tel: +33 1 01 12 34 56",
+                            SubjectCode = "AAI",
+                        },
+                        new SpecificationModels.BasicWL.Note()
+                        {
+                            Content = "APE 5510Z – TVA FR40123456824",
+                            SubjectCode = "AAI",
+                        },
+                        new SpecificationModels.BasicWL.Note()
+                        {
+                            Content =
+                                "La loi n°92/1442 du 31 décembre 1992 nous fait l’obligation de vous indiquer que le non-respect des conditions de paiement entraine des intérêts de retard suivant modalités et taux défini par la loi.",
+                            SubjectCode = "PMD",
+                        },
+                        new SpecificationModels.BasicWL.Note()
+                        {
+                            Content =
+                                "Une indemnité forfaitaire de 40€ sera due pour frais de recouvrement en cas de retard de paiement.",
+                            SubjectCode = "PMT",
+                        },
+                    },
+                },
+                ExchangedDocumentContext =
+                    new SpecificationModels.Minimum.ExchangedDocumentContext()
+                    {
+                        BusinessProcessSpecifiedDocumentContextParameter =
+                            new SpecificationModels.Minimum.DocumentContextParameter()
+                            {
+                                ID = new SpecificationModels.Minimum.ID() { Value = "A1" },
+                            },
+                        GuidelineSpecifiedDocumentContextParameter =
+                            new SpecificationModels.Minimum.DocumentContextParameter()
+                            {
+                                ID = new SpecificationModels.Minimum.ID()
+                                {
+                                    Value = "urn:cen.eu:en16931:2017",
+                                },
+                            },
+                    },
+                SupplyChainTradeTransaction =
+                    new SpecificationModels.EN16931.SupplyChainTradeTransaction()
+                    {
+                        IncludedSupplyChainTradeLineItem =
+                            new SpecificationModels.EN16931.SupplyChainTradeLineItem[]
+                            {
+                                new SpecificationModels.EN16931.SupplyChainTradeLineItem()
+                                {
+                                    AssociatedDocumentLineDocument =
+                                        new SpecificationModels.Basic.DocumentLineDocument()
+                                        {
+                                            LineID = new SpecificationModels.Minimum.ID
+                                            {
+                                                Value = "1",
+                                            },
+                                        },
+                                    SpecifiedTradeProduct =
+                                        new SpecificationModels.EN16931.TradeProduct()
+                                        {
+                                            Name = "Chambre du 09/08/2023 au 15/08/2023",
+                                        },
+                                    SpecifiedLineTradeAgreement =
+                                        new SpecificationModels.EN16931.LineTradeAgreement()
+                                        {
+                                            NetPriceProductTradePrice =
+                                                new SpecificationModels.Basic.TradePrice()
+                                                {
+                                                    ChargeAmount =
+                                                        new SpecificationModels.Minimum.Amount
+                                                        {
+                                                            Value = 205.9000m,
+                                                        },
+                                                    BasisQuantity =
+                                                        new SpecificationModels.Basic.Quantity()
+                                                        {
+                                                            UnitCode = "C62",
+                                                            Value = 6.0000m,
+                                                        },
+                                                },
+                                                        },
+                                    SpecifiedLineTradeSettlement =
+                                        new SpecificationModels.EN16931.LineTradeSettlement()
+                                        {
+                                            ApplicableTradeTax =
+                                                new SpecificationModels.EN16931.TradeTaxEN16931()
+                                                {
+                                                    TypeCode = "VAT",
+                                                    CategoryCode = "S",
+                                                    RateApplicablePercent = 10.00m,
+                                                },
+                                            SpecifiedTradeSettlementLineMonetarySummation =
+                                                new SpecificationModels.Basic.TradeSettlementLineMonetarySummation()
+                                                {
+                                                    LineTotalAmount =
+                                                        new SpecificationModels.Minimum.Amount
+                                                        {
+                                                            Value = 1235.40m,
+                                                        },
+                                                },
+                                                            },
+                                    SpecifiedLineTradeDelivery =
+                                        new SpecificationModels.Basic.LineTradeDelivery()
+                                        {
+                                            BilledQuantity =
+                                                new SpecificationModels.Basic.Quantity()
+                                                {
+                                                    UnitCode = "C62",
+                                                    Value = 6.0000m,
+                                                },
+                                        },
+                                },
+                                new SpecificationModels.EN16931.SupplyChainTradeLineItem()
+                                {
+                                    AssociatedDocumentLineDocument =
+                                        new SpecificationModels.Basic.DocumentLineDocument()
+                                        {
+                                            LineID = new ID { Value = "2" },
+                                        },
+                                    SpecifiedTradeProduct =
+                                        new SpecificationModels.EN16931.TradeProduct()
+                                        {
+                                            Name = "Forfait taxe de séjour",
+                                        },
+                                    SpecifiedLineTradeAgreement =
+                                        new SpecificationModels.EN16931.LineTradeAgreement()
+                                        {
+                                            NetPriceProductTradePrice =
+                                                new SpecificationModels.Basic.TradePrice()
+                                                {
+                                                    ChargeAmount =
+                                                        new SpecificationModels.Minimum.Amount
+                                                        {
+                                                            Value = 1.65m,
+                                                        },
+                                                    BasisQuantity =
+                                                        new SpecificationModels.Basic.Quantity()
+                                                        {
+                                                            UnitCode = "C62",
+                                                            Value = 6.0000m,
+                                                        },
+                                                },
+                                        },
+                                    SpecifiedLineTradeSettlement =
+                                        new SpecificationModels.EN16931.LineTradeSettlement()
+                                        {
+                                            ApplicableTradeTax =
+                                                new SpecificationModels.EN16931.TradeTaxEN16931()
+                                                {
+                                                    TypeCode = "VAT",
+                                                    CategoryCode = "Z",
+                                                    RateApplicablePercent = 0.00m,
+                                                },
+                                            SpecifiedTradeSettlementLineMonetarySummation =
+                                                new SpecificationModels.Basic.TradeSettlementLineMonetarySummation()
+                                                {
+                                                    LineTotalAmount =
+                                                        new SpecificationModels.Minimum.Amount
+                                                        {
+                                                            Value = 9.90m,
+                                                        },
+                                                },
+                                        },
+                                    SpecifiedLineTradeDelivery =
+                                        new SpecificationModels.Basic.LineTradeDelivery()
+                                        {
+                                            BilledQuantity =
+                                                new SpecificationModels.Basic.Quantity()
+                                                {
+                                                    UnitCode = "C62",
+                                                    Value = 6.0000m,
+                                                },
+                                        },
+                                },
+                            },
+                        ApplicableHeaderTradeAgreement =
+                            new SpecificationModels.EN16931.HeaderTradeAgreement()
+                            {
+                                SellerTradeParty =
+                                    new SpecificationModels.EN16931.TradePartyEN16931()
+                                    {
+                                        Name = "Société Hôtelière du Pacano",
+                                        SpecifiedLegalOrganization =
+                                            new SpecificationModels.BasicWL.LegalOrganization()
+                                            {
+                                                ID = new SpecificationModels.Minimum.ID()
+                                                {
+                                                    Value = "12345682400016",
+                                                    SchemeID = "0002",
+                                                },
+                                            },
+                                        PostalTradeAddress =
+                                            new SpecificationModels.BasicWL.TradeAddress()
+                                            {
+                                                CountryID = "FR",
+                                                PostcodeCode = "75000",
+                                                LineOne = "2, rue de la Paix",
+                                                CityName = "PARIS",
+                                            },
+                                        URIUniversalCommunication =
+                                            new SpecificationModels.BasicWL.UniversalCommunication()
+                                            {
+                                                URIID = new SpecificationModels.Minimum.ID()
+                                                {
+                                                    Value = "info@hotel-du-pacano.fr",
+                                                    SchemeID = "EM",
+                                                },
+                                            },
+                                        SpecifiedTaxRegistration =
+                                            new SpecificationModels.Minimum.TaxRegistration[]
+                                            {
+                                                new SpecificationModels.Minimum.TaxRegistration()
+                                                {
+                                                    ID = new SpecificationModels.Minimum.ID()
+                                                    {
+                                                        Value = "FR40123456824",
+                                                        SchemeID = "VA",
+                                                    },
+                                                },
+                                            },
+                                    },
+                                BuyerTradeParty =
+                                    new SpecificationModels.EN16931.TradePartyEN16931()
+                                    {
+                                        Name = "Securibox SARL",
+                                        SpecifiedLegalOrganization =
+                                            new SpecificationModels.BasicWL.LegalOrganization()
+                                            {
+                                                ID = new SpecificationModels.Minimum.ID()
+                                                {
+                                                    Value = "50000371000034",
+                                                    SchemeID = "0002",
+                                                },
+                                            },
+                                        SpecifiedTaxRegistration =
+                                            new SpecificationModels.Minimum.TaxRegistration[]
+                                            {
+                                                new SpecificationModels.Minimum.TaxRegistration
+                                                {
+                                                    ID = new SpecificationModels.Minimum.ID()
+                                                    {
+                                                        Value = "FR38500003710",
+                                                        SchemeID = "VA",
+                                                    },
+                                                },
+                                            },
+                                        PostalTradeAddress =
+                                            new SpecificationModels.BasicWL.TradeAddress()
+                                            {
+                                                CountryID = "FR",
+                                                PostcodeCode = "75008",
+                                                LineOne = "27, Rue de Bassano",
+                                                CityName = "Paris",
+                                            },
+                                    },
+                            },
+                        ApplicableHeaderTradeDelivery =
+                            new SpecificationModels.EN16931.HeaderTradeDelivery()
+                            {
+                        //        ShipToTradeParty =
+                        //            new SpecificationModels.EN16931.TradePartyEN16931()
+                        //            {
+                        //                Name = "Securibox SARL",
+                        //            },
                             },
                         ApplicableHeaderTradeSettlement =
                             new SpecificationModels.EN16931.HeaderTradeSettlement()
@@ -1061,6 +1462,50 @@ namespace Securibox.FacturX.Tests.FacturxExporterTests
                     .TotalPrepaidAmount
                     .Value,
                 Is.EqualTo(452.98m)
+            );
+        }
+
+        [Test]
+        [Order(4)]
+        public async Task WriteData_no_delivery_Stream_EN16931_SUCCESS()
+        {
+            var invoice = GetInvoice_SpecificationModels_witout_TradeDelivery();
+            var exporter = new FacturxExporter();
+
+            using var stream = exporter.CreateFacturXStream(
+                File.Open(srcFile, FileMode.Open, FileAccess.Read, FileShare.Read),
+                invoice,
+                $"SEPEM: Invoice ",
+                $"Invoice "
+            );
+
+            using var fileStream = new FileStream(tmpFile, FileMode.Create);
+            await stream.CopyToAsync(fileStream);
+
+            Assert.That(File.Exists(tmpFile), Is.True);
+            Assert.That(exporter.Errors, Is.Empty);
+            Assert.That(
+                exporter.Warnings.Any(w => w.Description.Contains("PEPPOL-EN16931-R008")),
+                Is.True
+            );
+        }
+
+        [Test]
+        [Order(5)]
+        public void WriteData_no_delivery_Stream_EN16931_FailOnWarning_Throws()
+        {
+            var invoice = GetInvoice_SpecificationModels_witout_TradeDelivery();
+            var exporter = new FacturxExporter();
+
+            Assert.Throws<System.Exception>(() =>
+                exporter.CreateFacturXStream(
+                    File.Open(srcFile, FileMode.Open, FileAccess.Read, FileShare.Read),
+                    invoice,
+                    $"SEPEM: Invoice ",
+                    $"Invoice ",
+                    failOnError: true,
+                    failOnWarning: true
+                )
             );
         }
     }

--- a/Securibox.FacturX.Tests/FacturxExporterTests/ExtendedInvoiceTests.cs
+++ b/Securibox.FacturX.Tests/FacturxExporterTests/ExtendedInvoiceTests.cs
@@ -1115,7 +1115,7 @@ namespace Securibox.FacturX.Tests.FacturxExporterTests
                 "Test Invoice with Incorrect VAT",
                 "Test Invoice",
                 // required because this test intentionally fails validation
-                failOnInvalid: false
+                failOnError: false
             );
 
             // using block is mandatory as FacturXImporter need the file being closed on Windows

--- a/Securibox.FacturX.Tests/RegressionTests/Test_0001_UnableToDeleteInputPDF.cs
+++ b/Securibox.FacturX.Tests/RegressionTests/Test_0001_UnableToDeleteInputPDF.cs
@@ -450,7 +450,7 @@ namespace Securibox.FacturX.Tests.RegressionTests
                         tmpPDFStreamFile,
                         GetModel(),
                         "Invoice",
-                        failOnInvalid: false
+                        failOnError: false
                     )
                 )
                 {
@@ -475,7 +475,7 @@ namespace Securibox.FacturX.Tests.RegressionTests
                 tmpPDFStreamFile,
                 GetModel(),
                 "Invoice",
-                failOnInvalid: false
+                failOnError: false
             );
 
             await stream.CopyToAsync(outStream);

--- a/Securibox.FacturX/FacturxExporter.cs
+++ b/Securibox.FacturX/FacturxExporter.cs
@@ -17,6 +17,12 @@ namespace Securibox.FacturX
         private ILogger<FacturxExporter> _logger;
         public List<ValidationReport> validationReport;
 
+        public IReadOnlyList<ValidationReport> Errors =>
+            validationReport.Where(r => r.IsError).ToList();
+
+        public IReadOnlyList<ValidationReport> Warnings =>
+            validationReport.Where(r => r.IsWarning).ToList();
+
         public FacturxExporter(ILogger<FacturxExporter>? logger = null)
         {
             _logger = InitializeLogger(logger);
@@ -29,7 +35,8 @@ namespace Securibox.FacturX
             FacturXConformanceLevelType conformanceLevel,
             string documentTitle = "Invoice",
             string documentDescription = "Invoice description",
-            bool failOnInvalid = true
+            bool failOnError = true,
+            bool failOnWarning = false
         )
         {
             if (!File.Exists(pdfPath))
@@ -51,7 +58,8 @@ namespace Securibox.FacturX
                 conformanceLevel,
                 documentTitle,
                 documentDescription,
-                failOnInvalid
+                failOnError,
+                failOnWarning
             );
         }
 
@@ -61,7 +69,8 @@ namespace Securibox.FacturX
             Invoice invoice,
             string documentTitle = "Invoice",
             string documentDescription = "Invoice description",
-            bool failOnInvalid = true
+            bool failOnError = true,
+            bool failOnWarning = false
         )
         {
             if (!File.Exists(pdfPath))
@@ -105,7 +114,8 @@ namespace Securibox.FacturX
                 conformanceLevel,
                 documentTitle,
                 documentDescription,
-                failOnInvalid
+                failOnError,
+                failOnWarning
             );
         }
 
@@ -114,7 +124,8 @@ namespace Securibox.FacturX
             ICrossIndustryInvoice invoice,
             string documentTitle = "Invoice",
             string documentDescription = "Invoice description",
-            bool failOnInvalid = true
+            bool failOnError = true,
+            bool failOnWarning = false
         )
         {
             if (!File.Exists(pdfPath))
@@ -129,7 +140,8 @@ namespace Securibox.FacturX
                 invoice,
                 documentTitle,
                 documentDescription,
-                failOnInvalid
+                failOnError,
+                failOnWarning
             );
         }
 
@@ -138,7 +150,8 @@ namespace Securibox.FacturX
             ICrossIndustryInvoice invoice,
             string documentTitle = "Invoice",
             string documentDescription = "Invoice description",
-            bool failOnInvalid = true
+            bool failOnError = true,
+            bool failOnWarning = false
         )
         {
             ArgumentNullException.ThrowIfNull(pdfStream);
@@ -193,7 +206,8 @@ namespace Securibox.FacturX
                 conformanceLevel,
                 documentTitle,
                 documentDescription,
-                failOnInvalid
+                failOnError,
+                failOnWarning
             );
         }
 
@@ -203,7 +217,8 @@ namespace Securibox.FacturX
             FacturXConformanceLevelType conformanceLevel,
             string documentTitle = "Invoice",
             string documentDescription = "Invoice description",
-            bool failOnInvalid = true
+            bool failOnError = true,
+            bool failOnWarning = false
         )
         {
             ArgumentNullException.ThrowIfNull(pdfStream);
@@ -226,7 +241,11 @@ namespace Securibox.FacturX
                     .ToList();
             }
 
-            if (failOnInvalid && validationReport.Any(report => report.IsError))
+            var hasBlockingError = failOnError && validationReport.Any(report => report.IsError);
+            var hasBlockingWarning =
+                failOnWarning && validationReport.Any(report => report.IsWarning);
+
+            if (hasBlockingError || hasBlockingWarning)
             {
                 throw new Exception(
                     "The provided XML is not valid according to the selected Factur-X conformance level. "

--- a/Securibox.FacturX/Schematron/Types/Assert.cs
+++ b/Securibox.FacturX/Schematron/Types/Assert.cs
@@ -107,11 +107,14 @@ namespace Securibox.FacturX.Schematron.Types
 
             assert = System.Text.RegularExpressions.Regex.Replace(assert, @"\s+", " ");
             result = EvaluateLogicalExpression(context, navigator, assert);
+            var failed = !result;
+            var isWarningFlag = string.Equals(this.Flag, "warning", StringComparison.OrdinalIgnoreCase);
 
             return new EvaluationResult
             {
                 Assertion = this,
-                IsError = !result,
+                IsError = failed && !isWarningFlag,
+                IsWarning = failed && isWarningFlag,
                 AssertInnerText = this.EvaluateDescriptionFragment(context),
             };
         }


### PR DESCRIPTION
Hello

I suggest amending the code as follows because the rules R08 is a warning.

In  Assert.cs :

```
 result = EvaluateLogicalExpression(context, navigator, assert);
            var failed = !result;
            var isWarningFlag = string.Equals(this.Flag, "warning", StringComparison.OrdinalIgnoreCase);
```

In FacturxExporter.cs :

Added `failOnError` and `failOnWarning` to clearly distinguish between the two on schema validation
```
CreateFacturXStream(
                pdfStream,
                xmlStream,
                conformanceLevel,
                documentTitle,
                documentDescription,
                failOnError,
                failOnWarning
            );
```

and I’ll add the list of errors and warnings

```
public class FacturxExporter
    {
        private ILogger<FacturxExporter> _logger;
        public List<ValidationReport> validationReport;

        public IReadOnlyList<ValidationReport> **Errors** =>
            validationReport.Where(r => r.IsError).ToList();

        public IReadOnlyList<ValidationReport> **Warnings** =>
            validationReport.Where(r => r.IsWarning).ToList();

```

